### PR TITLE
Implement CRUD stubs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,1 +1,14 @@
-idf_component_register(SRCS "main.c" INCLUDE_DIRS ".")
+idf_component_register(
+    SRCS
+        "main/main.c"
+        "components/core/animals/animals.c"
+        "components/core/ui/ui_animals.c"
+        "components/core/utils/logging.c"
+        "components/storage/storage.c"
+    INCLUDE_DIRS
+        "main"
+        "components/core/animals"
+        "components/core/ui"
+        "components/core/utils"
+        "components/storage"
+)

--- a/components/core/animals/animals.c
+++ b/components/core/animals/animals.c
@@ -1,1 +1,63 @@
-// Gestion des fiches animaux CRUD
+// Simple in-memory CRUD implementation for animal entries
+
+#include "animals.h"
+#include <string.h>
+
+#define MAX_ANIMALS 10
+
+static animal_t s_animals[MAX_ANIMALS];
+static size_t s_count = 0;
+
+void animals_init(void)
+{
+    s_count = 0;
+    memset(s_animals, 0, sizeof(s_animals));
+}
+
+bool animals_create(const animal_t *animal)
+{
+    if (!animal || s_count >= MAX_ANIMALS) {
+        return false;
+    }
+    s_animals[s_count] = *animal;
+    s_count++;
+    return true;
+}
+
+const animal_t *animals_get(size_t index)
+{
+    if (index >= s_count) {
+        return NULL;
+    }
+    return &s_animals[index];
+}
+
+bool animals_update(size_t index, const animal_t *animal)
+{
+    if (!animal || index >= s_count) {
+        return false;
+    }
+    s_animals[index] = *animal;
+    return true;
+}
+
+bool animals_delete(size_t index)
+{
+    if (index >= s_count) {
+        return false;
+    }
+
+    for (size_t i = index; i + 1 < s_count; ++i) {
+        s_animals[i] = s_animals[i + 1];
+    }
+
+    memset(&s_animals[s_count - 1], 0, sizeof(animal_t));
+    s_count--;
+    return true;
+}
+
+size_t animals_get_count(void)
+{
+    return s_count;
+}
+

--- a/components/core/animals/animals.h
+++ b/components/core/animals/animals.h
@@ -1,3 +1,28 @@
 #pragma once
 
-// Animals header
+#include <stdbool.h>
+#include <stddef.h>
+
+// Simple in-memory representation of an animal
+typedef struct {
+    char name[32];
+    int age;
+} animal_t;
+
+// Initialize the internal list of animals
+void animals_init(void);
+
+// Create a new animal entry. Returns true on success.
+bool animals_create(const animal_t *animal);
+
+// Retrieve an animal by index. Returns NULL if index is out of range.
+const animal_t *animals_get(size_t index);
+
+// Update an existing animal entry. Returns true on success.
+bool animals_update(size_t index, const animal_t *animal);
+
+// Delete an animal entry by index. Returns true on success.
+bool animals_delete(size_t index);
+
+// Return the current number of stored animals.
+size_t animals_get_count(void);

--- a/components/storage/storage.c
+++ b/components/storage/storage.c
@@ -1,1 +1,35 @@
-// JSON LittleFS CRUD
+// Minimal stub implementation of JSON storage helpers
+
+#include "storage.h"
+#include <string.h>
+
+// In a full application this would interface with LittleFS or another
+// filesystem. These stubs simply pretend that the operations succeed.
+
+bool storage_init(void)
+{
+    // Nothing to initialise in the stub
+    return true;
+}
+
+bool storage_save(const char *path, const char *data, size_t len)
+{
+    (void)path;
+    (void)len;
+    // Operation would normally write data to a file
+    // We simply return true to indicate success
+    (void)data;
+    return true;
+}
+
+bool storage_load(const char *path, char *buffer, size_t len)
+{
+    (void)path;
+    if (buffer && len > 0) {
+        // Return an empty JSON array by default
+        strncpy(buffer, "[]", len - 1);
+        buffer[len - 1] = '\0';
+    }
+    return true;
+}
+

--- a/components/storage/storage.h
+++ b/components/storage/storage.h
@@ -1,3 +1,14 @@
 #pragma once
 
-// Storage header
+#include <stdbool.h>
+#include <stddef.h>
+
+// Initialize the storage subsystem. Returns true on success.
+bool storage_init(void);
+
+// Save raw JSON data at the given path. Returns true on success.
+bool storage_save(const char *path, const char *data, size_t len);
+
+// Load raw JSON data from the given path. The buffer will be null terminated
+// if there is space. Returns true on success.
+bool storage_load(const char *path, char *buffer, size_t len);

--- a/main/main.c
+++ b/main/main.c
@@ -1,1 +1,8 @@
-void app_main(void) {}
+#include "core/animals/animals.h"
+#include "storage/storage.h"
+
+void app_main(void)
+{
+    animals_init();
+    storage_init();
+}


### PR DESCRIPTION
## Summary
- flesh out animal management with simple in-memory CRUD functions
- add stubbed JSON storage helpers
- wire sources into CMake and call init functions from `app_main`

## Testing
- `gcc -c main/main.c components/core/animals/animals.c components/storage/storage.c components/core/utils/logging.c components/core/ui/ui_animals.c -I./components -Icomponents/core/animals -Icomponents/storage -Icomponents/core/utils -Icomponents/core/ui -I./main`

------
https://chatgpt.com/codex/tasks/task_e_68588becc1fc8323b97e7a1d718643bd