### PR TITLE
Add unit tests

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,14 @@
+CC ?= gcc
+CFLAGS = -I../components/core/animals -I../components/storage
+
+TESTS = test_animals test_storage
+
+all: $(TESTS)
+
+%: %.c ../components/core/animals/animals.c ../components/storage/storage.c
+	$(CC) $(CFLAGS) $^ -o $@
+
+clean:
+	rm -f $(TESTS)
+
+.PHONY: all clean

--- a/tests/test_animals.c
+++ b/tests/test_animals.c
@@ -1,0 +1,39 @@
+#include "../components/core/animals/animals.h"
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+int main(void)
+{
+    animals_init();
+    assert(animals_get_count() == 0);
+
+    animal_t a;
+    memset(&a, 0, sizeof(a));
+    strcpy(a.name, "Gecko");
+    a.age = 2;
+    assert(animals_create(&a));
+    assert(animals_get_count() == 1);
+
+    const animal_t *pa = animals_get(0);
+    assert(pa);
+    assert(strcmp(pa->name, "Gecko") == 0);
+    assert(pa->age == 2);
+
+    animal_t b;
+    memset(&b, 0, sizeof(b));
+    strcpy(b.name, "Lizard");
+    b.age = 3;
+    assert(animals_update(0, &b));
+
+    pa = animals_get(0);
+    assert(pa);
+    assert(strcmp(pa->name, "Lizard") == 0);
+    assert(pa->age == 3);
+
+    assert(animals_delete(0));
+    assert(animals_get_count() == 0);
+
+    printf("test_animals: all tests passed\n");
+    return 0;
+}

--- a/tests/test_storage.c
+++ b/tests/test_storage.c
@@ -1,0 +1,19 @@
+#include "../components/storage/storage.h"
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+int main(void)
+{
+    assert(storage_init());
+
+    char buffer[16];
+    memset(buffer, 0, sizeof(buffer));
+    assert(storage_load("/animals.json", buffer, sizeof(buffer)));
+    assert(strcmp(buffer, "[]") == 0);
+
+    assert(storage_save("/animals.json", "{}", 2));
+
+    printf("test_storage: all tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add simple Makefile-based unit test harness under `tests/`
- test `animals` CRUD logic
- test storage stubs

## Testing
- `make -C tests clean all`
- `./tests/test_animals && ./tests/test_storage`


------
https://chatgpt.com/codex/tasks/task_e_68588eaa75008323bf33241a312d2bf3