### PR TITLE
Implement basic logging helpers

### DIFF
--- a/components/core/utils/CMakeLists.txt
+++ b/components/core/utils/CMakeLists.txt
@@ -1,4 +1,5 @@
 idf_component_register(
     SRCS "logging.c"
     INCLUDE_DIRS "."
+    REQUIRES esp_log
 )

--- a/components/core/utils/logging.c
+++ b/components/core/utils/logging.c
@@ -1,1 +1,21 @@
-// Logging utilitaires
+// Logging utilities
+
+#include "logging.h"
+#include "esp_log.h"
+
+void log_info(const char *tag, const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    esp_log_writev(ESP_LOG_INFO, tag, fmt, args);
+    va_end(args);
+}
+
+void log_error(const char *tag, const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    esp_log_writev(ESP_LOG_ERROR, tag, fmt, args);
+    va_end(args);
+}
+

--- a/components/core/utils/logging.h
+++ b/components/core/utils/logging.h
@@ -1,3 +1,12 @@
 #pragma once
 
-// Logging header
+#include <stdarg.h>
+
+// Simple logging helpers built on top of ESP-IDF's logging facilities
+
+// Log an informational message using the given tag
+void log_info(const char *tag, const char *fmt, ...) __attribute__((format(printf, 2, 3)));
+
+// Log an error message using the given tag
+void log_error(const char *tag, const char *fmt, ...) __attribute__((format(printf, 2, 3)));
+


### PR DESCRIPTION
## Summary
- add info and error logging helpers using ESP-IDF log API
- require `esp_log` for the utils component

## Testing
- `make -C tests clean all`
- `./tests/test_animals && ./tests/test_storage`


------
https://chatgpt.com/codex/tasks/task_e_685893de03a48323b22e3f87a5c565d6