### PR TITLE
Implement real storage using host filesystem

### DIFF
--- a/components/storage/storage.c
+++ b/components/storage/storage.c
@@ -1,35 +1,89 @@
-// Minimal stub implementation of JSON storage helpers
+// Simple filesystem-backed implementation of JSON storage helpers
 
 #include "storage.h"
+
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 
-// In a full application this would interface with LittleFS or another
-// filesystem. These stubs simply pretend that the operations succeed.
+// Base directory used as the mounted filesystem path. By default this
+// resolves to "data" but can be overridden at runtime via the
+// STORAGE_BASE_PATH environment variable which is useful for tests.
+static char s_mount_path[256] = "data";
+static bool s_initialised = false;
 
+// Ensure the mount directory exists
+static bool ensure_dir(const char *path)
+{
+    struct stat st;
+    if (stat(path, &st) == 0) {
+        return S_ISDIR(st.st_mode);
+    }
+    if (mkdir(path, 0755) != 0) {
+        return false;
+    }
+    return true;
+}
+
+// Mount the filesystem. For the host build this simply verifies that the
+// directory exists so standard C file APIs can be used.
 bool storage_init(void)
 {
-    // Nothing to initialise in the stub
+    const char *env = getenv("STORAGE_BASE_PATH");
+    if (env && env[0] != '\0') {
+        strncpy(s_mount_path, env, sizeof(s_mount_path) - 1);
+        s_mount_path[sizeof(s_mount_path) - 1] = '\0';
+    }
+
+    if (!ensure_dir(s_mount_path)) {
+        return false;
+    }
+
+    s_initialised = true;
     return true;
 }
 
+// Save raw data to a file within the mounted directory
 bool storage_save(const char *path, const char *data, size_t len)
 {
-    (void)path;
-    (void)len;
-    // Operation would normally write data to a file
-    // We simply return true to indicate success
-    (void)data;
-    return true;
+    if (!s_initialised || !path || !data) {
+        return false;
+    }
+
+    char full_path[512];
+    snprintf(full_path, sizeof(full_path), "%s%s", s_mount_path, path);
+
+    FILE *f = fopen(full_path, "wb");
+    if (!f) {
+        return false;
+    }
+
+    size_t written = fwrite(data, 1, len, f);
+    fclose(f);
+
+    return written == len;
 }
 
+// Load data from a file within the mounted directory
 bool storage_load(const char *path, char *buffer, size_t len)
 {
-    (void)path;
-    if (buffer && len > 0) {
-        // Return an empty JSON array by default
-        strncpy(buffer, "[]", len - 1);
-        buffer[len - 1] = '\0';
+    if (!s_initialised || !path || !buffer || len == 0) {
+        return false;
     }
+
+    char full_path[512];
+    snprintf(full_path, sizeof(full_path), "%s%s", s_mount_path, path);
+
+    FILE *f = fopen(full_path, "rb");
+    if (!f) {
+        return false;
+    }
+
+    size_t read = fread(buffer, 1, len - 1, f);
+    fclose(f);
+    buffer[read] = '\0';
+
     return true;
 }
 

--- a/tests/test_storage.c
+++ b/tests/test_storage.c
@@ -1,11 +1,42 @@
 #include "../components/storage/storage.h"
 #include <assert.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
+
+static void prepare_animals_json(const char *dir)
+{
+    char path[512];
+    snprintf(path, sizeof(path), "%s/animals.json", dir);
+    FILE *f = fopen(path, "w");
+    assert(f);
+    fputs("[]", f);
+    fclose(f);
+}
+
+static void verify_file_contents(const char *path, const char *expected)
+{
+    FILE *f = fopen(path, "r");
+    assert(f);
+    char buf[16];
+    size_t n = fread(buf, 1, sizeof(buf) - 1, f);
+    fclose(f);
+    buf[n] = '\0';
+    assert(strcmp(buf, expected) == 0);
+}
 
 int main(void)
 {
+    char tmp_template[] = "/tmp/storageXXXXXX";
+    char *tmpdir = mkdtemp(tmp_template);
+    assert(tmpdir);
+
+    setenv("STORAGE_BASE_PATH", tmpdir, 1);
+
     assert(storage_init());
+
+    prepare_animals_json(tmpdir);
 
     char buffer[16];
     memset(buffer, 0, sizeof(buffer));
@@ -13,6 +44,13 @@ int main(void)
     assert(strcmp(buffer, "[]") == 0);
 
     assert(storage_save("/animals.json", "{}", 2));
+
+    char full_path[512];
+    snprintf(full_path, sizeof(full_path), "%s/animals.json", tmpdir);
+    verify_file_contents(full_path, "{}");
+
+    unlink(full_path);
+    rmdir(tmpdir);
 
     printf("test_storage: all tests passed\n");
     return 0;


### PR DESCRIPTION
## Summary
- add a simple filesystem-backed implementation of `storage.c`
- mount storage in `storage_init` by checking `STORAGE_BASE_PATH`
- update storage unit test to use a temporary directory

## Testing
- `make -C tests clean all`
- `./tests/test_animals`
- `./tests/test_storage`


------
https://chatgpt.com/codex/tasks/task_e_685898e9c5ac8323ad351787e15c1793