### PR TITLE
Update docs for tests, data file, and wiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,53 @@ stored on the device for display.
    idf.py -p /dev/ttyUSB0 flash monitor
    ```
 5. Place any JSON data (e.g. `data/animals.json`) onto the target storage if required.
+
+## Running unit tests
+
+The repository provides a very small test suite that can be executed on the host
+without ESP‑IDF. Simply change into the `tests` directory and run `make`:
+
+```bash
+cd tests
+make
+```
+
+This will build two executables, `test_animals` and `test_storage`. Run them to
+verify the core components:
+
+```bash
+./test_animals
+./test_storage
+```
+
+Both programs print a confirmation message when the tests pass.
+
+## Sample data file
+
+The `data/animals.json` file contains example reptile entries in JSON format.
+At runtime the application can load this file using `storage_load("/animals.json", ...)`
+after calling `storage_init()`. The JSON is then parsed and used to populate the
+in‑memory list managed by `animals.c`.
+
+## Wiring
+
+Below is a minimal reference for connecting the LCD and touch controllers. See
+the driver headers for additional context.
+
+### ST7262 LCD
+
+- SPI MOSI &rarr; SDI
+- SPI CLK  &rarr; SCL
+- Chip select driven low while transferring
+- DC pin selects between command (low) and data (high)
+- Optional reset line held low briefly on startup
+
+### GT911 touch controller
+
+- Uses I<sup>2</sup>C
+- SDA connected to the chosen I2C SDA pin
+- SCL connected to the chosen I2C SCL pin
+- The address defaults to `0x5D` but can be changed in software
+
+For complete pinouts refer to the datasheets for the specific LCD and touch
+modules you are using.


### PR DESCRIPTION
## Summary
- explain how to build and run the host unit tests
- document the sample `animals.json` file and how it's read
- add wiring information for ST7262 LCD and GT911 touch controller

## Testing
- `make -C tests`
- `./tests/test_animals`
- `./tests/test_storage`


------
https://chatgpt.com/codex/tasks/task_e_685899f8f1d08323bfc71fa050638e56