### PR TITLE
Fix logging dependency

### DIFF
--- a/components/core/utils/CMakeLists.txt
+++ b/components/core/utils/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
     SRCS "logging.c"
     INCLUDE_DIRS "."
-    REQUIRES esp_log
+    REQUIRES log
 )


### PR DESCRIPTION
## Summary
- rename `esp_log` dependency to `log`

## Testing
- `cd tests && make`
- `./test_animals`
- `./test_storage`
- `./test_logging`
- `./test_ui`


------
https://chatgpt.com/codex/tasks/task_e_68591c256ccc8323866f9dd50d011648