### PR TITLE
Fix component discovery in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,7 @@ cmake_minimum_required(VERSION 3.5)
 
 # Add component directories nested under components/
 set(EXTRA_COMPONENT_DIRS
-    ${CMAKE_CURRENT_LIST_DIR}/components/core
-    ${CMAKE_CURRENT_LIST_DIR}/components/drivers
+    ${CMAKE_CURRENT_LIST_DIR}/components
 )
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)


### PR DESCRIPTION
## Summary
- include the entire `components` folder in EXTRA_COMPONENT_DIRS so storage and future components are detected

## Testing
- `make -C tests clean all`
- `./test_animals && ./test_storage && ./test_logging && ./test_ui`


------
https://chatgpt.com/codex/tasks/task_e_68591d1607bc8323812754d43bc26b3c