### PR TITLE
Fix component discovery by adding manifests

### DIFF
--- a/components/core/animals/idf_component.yml
+++ b/components/core/animals/idf_component.yml
@@ -1,0 +1,4 @@
+version: "0.1.0"
+description: "Animal data management"
+dependencies:
+  idf: ">=5.0"

--- a/components/core/ui/idf_component.yml
+++ b/components/core/ui/idf_component.yml
@@ -1,0 +1,6 @@
+version: "0.1.0"
+description: "UI helpers for animals"
+dependencies:
+  idf: ">=5.0"
+  animals: "*"
+  lvgl: "*"

--- a/components/core/utils/idf_component.yml
+++ b/components/core/utils/idf_component.yml
@@ -1,0 +1,5 @@
+version: "0.1.0"
+description: "Utility helpers"
+dependencies:
+  idf: ">=5.0"
+  log: "*"

--- a/components/drivers/lcd_st7262/idf_component.yml
+++ b/components/drivers/lcd_st7262/idf_component.yml
@@ -1,0 +1,6 @@
+version: "0.1.0"
+description: "ST7262 LCD driver"
+dependencies:
+  idf: ">=5.0"
+  lvgl: "*"
+  utils: "*"

--- a/components/drivers/touch_gt911/idf_component.yml
+++ b/components/drivers/touch_gt911/idf_component.yml
@@ -1,0 +1,7 @@
+version: "0.1.0"
+description: "GT911 touch driver"
+dependencies:
+  idf: ">=5.0"
+  driver: "*"
+  utils: "*"
+  lvgl: "*"

--- a/components/storage/idf_component.yml
+++ b/components/storage/idf_component.yml
@@ -1,0 +1,4 @@
+version: "0.1.0"
+description: "Simple JSON storage"
+dependencies:
+  idf: ">=5.0"

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -1,0 +1,10 @@
+version: "0.1.0"
+description: "Main application"
+dependencies:
+  idf: ">=5.0"
+  animals: "*"
+  storage: "*"
+  ui: "*"
+  utils: "*"
+  lcd_st7262: "*"
+  touch_gt911: "*"


### PR DESCRIPTION
## Summary
- add `idf_component.yml` manifests for all components so ESP-IDF can find them

## Testing
- `make -C tests clean all`
- `./test_animals && ./test_storage && ./test_logging && ./test_ui`


------
https://chatgpt.com/codex/tasks/task_e_68593124f7108323821827ca0697082f