### PR TITLE
Quote component dirs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,12 +2,12 @@ cmake_minimum_required(VERSION 3.5)
 
 # List every component directory explicitly so ESP-IDF can find them
 set(EXTRA_COMPONENT_DIRS
-    ${CMAKE_CURRENT_LIST_DIR}/components/core/animals
-    ${CMAKE_CURRENT_LIST_DIR}/components/core/ui
-    ${CMAKE_CURRENT_LIST_DIR}/components/core/utils
-    ${CMAKE_CURRENT_LIST_DIR}/components/storage
-    ${CMAKE_CURRENT_LIST_DIR}/components/drivers/lcd_st7262
-    ${CMAKE_CURRENT_LIST_DIR}/components/drivers/touch_gt911
+    "${CMAKE_CURRENT_LIST_DIR}/components/core/animals"
+    "${CMAKE_CURRENT_LIST_DIR}/components/core/ui"
+    "${CMAKE_CURRENT_LIST_DIR}/components/core/utils"
+    "${CMAKE_CURRENT_LIST_DIR}/components/storage"
+    "${CMAKE_CURRENT_LIST_DIR}/components/drivers/lcd_st7262"
+    "${CMAKE_CURRENT_LIST_DIR}/components/drivers/touch_gt911"
 )
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)


### PR DESCRIPTION
## Summary
- quote each path in `EXTRA_COMPONENT_DIRS`

## Testing
- `idf.py set-target esp32s3 && idf.py build` *(fails: `idf.py` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68593fae244883239b394f687ffdabba