### PR TITLE
Fix pdMS_TO_TICKS reference in GT911 driver

### DIFF
--- a/components/drivers/touch_gt911/gt911.c
+++ b/components/drivers/touch_gt911/gt911.c
@@ -3,6 +3,8 @@
 #include "gt911.h"
 #include "core/utils/logging.h"
 #include "driver/i2c.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 
 // Default I2C address for the controller
 #define GT911_ADDR 0x5D


### PR DESCRIPTION
## Summary
- include FreeRTOS headers so `pdMS_TO_TICKS` works

## Testing
- `cd tests && make`
- `./test_animals && ./test_storage && ./test_logging && ./test_ui`


------
https://chatgpt.com/codex/tasks/task_e_68594e21810c8323b4c18867285f59ac