### PR TITLE
Add animal management buttons to UI

### DIFF
--- a/components/core/ui/ui_animals.c
+++ b/components/core/ui/ui_animals.c
@@ -2,9 +2,46 @@
 
 #include "ui_animals.h"
 #include "core/animals/animals.h"
+#include <stdio.h>
+#include <string.h>
 
 static lv_obj_t *s_screen = NULL;
 static lv_obj_t *s_list = NULL;
+static lv_obj_t *s_add_btn = NULL;
+static lv_obj_t *s_edit_btn = NULL;
+static lv_obj_t *s_delete_btn = NULL;
+
+static void on_add(lv_event_t *e)
+{
+    (void)e;
+    animal_t a = {0};
+    snprintf(a.name, sizeof(a.name), "Animal%zu", animals_get_count() + 1);
+    animals_create(&a);
+    ui_animals_refresh();
+}
+
+static void on_edit(lv_event_t *e)
+{
+    (void)e;
+    if (animals_get_count() == 0) {
+        return;
+    }
+    animal_t a = {0};
+    strncpy(a.name, "Edited", sizeof(a.name) - 1);
+    a.age = 99;
+    animals_update(0, &a);
+    ui_animals_refresh();
+}
+
+static void on_delete(lv_event_t *e)
+{
+    (void)e;
+    if (animals_get_count() == 0) {
+        return;
+    }
+    animals_delete(0);
+    ui_animals_refresh();
+}
 
 // Populate the list widget with the current animals
 void ui_animals_refresh(void)
@@ -38,6 +75,21 @@ lv_obj_t *ui_animals_create(void)
     s_screen = lv_obj_create(NULL);
     s_list = lv_list_create(s_screen);
     lv_obj_set_size(s_list, lv_pct(100), lv_pct(100));
+
+    s_add_btn = lv_btn_create(s_screen);
+    lv_obj_add_event_cb(s_add_btn, on_add);
+    lv_obj_t *add_label = lv_label_create(s_add_btn);
+    lv_label_set_text_fmt(add_label, "Add");
+
+    s_edit_btn = lv_btn_create(s_screen);
+    lv_obj_add_event_cb(s_edit_btn, on_edit);
+    lv_obj_t *edit_label = lv_label_create(s_edit_btn);
+    lv_label_set_text_fmt(edit_label, "Edit");
+
+    s_delete_btn = lv_btn_create(s_screen);
+    lv_obj_add_event_cb(s_delete_btn, on_delete);
+    lv_obj_t *delete_label = lv_label_create(s_delete_btn);
+    lv_label_set_text_fmt(delete_label, "Delete");
 
     ui_animals_refresh();
 

--- a/tests/stubs/lvgl.c
+++ b/tests/stubs/lvgl.c
@@ -45,3 +45,14 @@ void lv_label_set_text_fmt(lv_obj_t *label, const char *fmt, ...) {
     vsnprintf(label->text, sizeof(label->text), fmt, args);
     va_end(args);
 }
+
+void lv_obj_add_event_cb(lv_obj_t *obj, lv_event_cb_t cb) {
+    obj->event_cb = cb;
+}
+
+void lv_event_send(lv_obj_t *obj) {
+    if (obj && obj->event_cb) {
+        lv_event_t e = { .target = obj };
+        obj->event_cb(&e);
+    }
+}

--- a/tests/stubs/lvgl.h
+++ b/tests/stubs/lvgl.h
@@ -1,13 +1,22 @@
 #pragma once
 #include <stdarg.h>
 
+struct lv_event_s;
+typedef struct lv_event_s lv_event_t;
 typedef struct lv_obj_s {
     int type;
     char text[64];
     struct lv_obj_s *parent;
     struct lv_obj_s *children[16];
     int child_count;
+    void (*event_cb)(lv_event_t *);
 } lv_obj_t;
+
+struct lv_event_s {
+    lv_obj_t *target;
+};
+
+typedef void (*lv_event_cb_t)(lv_event_t *);
 
 static inline int lv_pct(int v) { return v; }
 
@@ -18,3 +27,5 @@ lv_obj_t *lv_label_create(lv_obj_t *parent);
 void lv_obj_set_size(lv_obj_t *obj, int w, int h);
 void lv_obj_clean(lv_obj_t *obj);
 void lv_label_set_text_fmt(lv_obj_t *label, const char *fmt, ...);
+void lv_obj_add_event_cb(lv_obj_t *obj, lv_event_cb_t cb);
+void lv_event_send(lv_obj_t *obj);

--- a/tests/test_ui.c
+++ b/tests/test_ui.c
@@ -19,12 +19,20 @@ int main(void)
     assert(screen);
     ui_animals_refresh();
 
-    // screen should have one child list
-    assert(screen->child_count == 1);
+    // screen has list and three control buttons
+    assert(screen->child_count == 4);
     lv_obj_t *list = screen->children[0];
+    lv_obj_t *btn_add = screen->children[1];
+    lv_obj_t *btn_edit = screen->children[2];
+    lv_obj_t *btn_del = screen->children[3];
     assert(list->child_count == 2);
 
-    // each button has a label child with text
+    // verify button labels
+    assert(strcmp(btn_add->children[0]->text, "Add") == 0);
+    assert(strcmp(btn_edit->children[0]->text, "Edit") == 0);
+    assert(strcmp(btn_del->children[0]->text, "Delete") == 0);
+
+    // verify initial list items
     for (int i=0;i<2;i++) {
         lv_obj_t *btn = list->children[i];
         assert(btn->child_count == 1);
@@ -35,6 +43,23 @@ int main(void)
             assert(strcmp(label->text, "Snake (4)") == 0);
         }
     }
+
+    // trigger Add button
+    lv_event_send(btn_add);
+    assert(animals_get_count() == 3);
+    assert(list->child_count == 3);
+    lv_obj_t *new_btn = list->children[2];
+    assert(strcmp(new_btn->children[0]->text, "Animal3 (0)") == 0);
+
+    // trigger Edit button
+    lv_event_send(btn_edit);
+    assert(strcmp(list->children[0]->children[0]->text, "Edited (99)") == 0);
+
+    // trigger Delete button
+    lv_event_send(btn_del);
+    assert(animals_get_count() == 2);
+    assert(list->child_count == 2);
+    assert(strcmp(list->children[0]->children[0]->text, "Snake (4)") == 0);
 
     printf("test_ui: all tests passed\n");
     return 0;


### PR DESCRIPTION
## Summary
- extend UI to include Add, Edit and Delete buttons
- hook buttons to animals CRUD operations
- add simple LVGL event support to stubs
- test new UI interactions

## Testing
- `make`
- `./test_animals`
- `./test_storage`
- `./test_logging`
- `./test_ui`


------
https://chatgpt.com/codex/tasks/task_e_685d32584c708323aaf587d45f7690fc