### PR TITLE
Add age field to animals example

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Both programs print a confirmation message when the tests pass.
 ## Sample data file
 
 The `data/animals.json` file contains example reptile entries in JSON format.
+Each entry now provides a `name` and an `age` field that `animals_load_from_json()`
+expects when populating the list.
 After calling `storage_init()` the application can populate the in‑memory list
 by invoking `animals_load_from_json()`, which internally uses
 `storage_load("/animals.json", ...)` and parses the JSON data.

--- a/data/animals.json
+++ b/data/animals.json
@@ -1,16 +1,19 @@
 [
   {
     "name": "Leo",
+    "age": 2,
     "species": "Leopard Gecko",
     "habitat": "Desert Terrarium"
   },
   {
     "name": "Shelly",
+    "age": 8,
     "species": "Russian Tortoise",
     "habitat": "Dry Grassland Enclosure"
   },
   {
     "name": "Fang",
+    "age": 4,
     "species": "Corn Snake",
     "habitat": "Tropical Vivarium"
   }


### PR DESCRIPTION
## Summary
- update JSON sample to include `age`
- clarify README about the new fields in the sample data

## Testing
- `make` and run tests


------
https://chatgpt.com/codex/tasks/task_e_685d38fa30d48323a563772a2c551fec